### PR TITLE
Added CodeQL to query bad use of structured logging

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,4 @@ name: "CFEngine cpp CodeQL config"
 queries:
   - uses: cfengine/core/.github/codeql/cpp-queries/bool-type-mismatch-return.ql@master
   - uses: cfengine/core/.github/codeql/cpp-queries/missing-argument-null-check.ql@master
+  - uses: cfengine/core/.github/codeql/cpp-queries/structured-logging-terminating-pair.ql@master

--- a/.github/codeql/cpp-queries/structured-logging-terminating-pair.c
+++ b/.github/codeql/cpp-queries/structured-logging-terminating-pair.c
@@ -1,0 +1,20 @@
+#include <logging.h>
+
+void good(void)
+{
+    // Does include "MESSAGE"
+    LogToSystemLogStructured(LOG_DEBUG, "FOO", "bogus", "BAR", "doofus", "MESSAGE", "%s!", "bonkers");
+}
+
+void bad(void)
+{
+    // Does not include "MESSAGE"
+    LogToSystemLogStructured(LOG_DEBUG, "FOO", "bogus", "BAR", "doofus", "BAZ", "%s!", "bonkers");
+}
+
+int main()
+{
+    good();
+    bad();
+    return 0;
+}

--- a/.github/codeql/cpp-queries/structured-logging-terminating-pair.qhelp
+++ b/.github/codeql/cpp-queries/structured-logging-terminating-pair.qhelp
@@ -1,0 +1,40 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+
+<p>
+Any use of the structured logging function <code>LogToSystemLogStructured<code>
+must include the terminating key-value pair containing the <code>"MESSAGE"<code>
+key followed by a format-string and its respective arguments representing the
+value.
+</p>
+
+</overview>
+<recommendation>
+
+<p>
+Make sure the terminating key-value pair containing the <code>"MESSAGE"</code>
+key is present.
+</p>
+
+</recommendation>
+<example>
+
+<p>
+This example has one correct (good) function, and one incorrect (bad) function:
+</p>
+
+<sample src="structured-logging-terminating-pair.c" />
+
+</example>
+<references>
+
+<li>
+CFEngine Contribution guidelines: <a href="https://github.com/cfengine/core/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>
+</li>
+
+</references>
+</qhelp>

--- a/.github/codeql/cpp-queries/structured-logging-terminating-pair.ql
+++ b/.github/codeql/cpp-queries/structured-logging-terminating-pair.ql
@@ -1,0 +1,18 @@
+/**
+ * @name Invalid use of structured logging function.
+ * @description Each call to LogToSystemLogStructured must include the terminating "MESSAGE" key.
+ * @kind problem
+ * @problem.severity error
+ * @id cpp/structured-logging-terminating-pair
+ * @tags correctness
+ *       security
+ * @precision very-high
+ */
+
+import cpp
+
+from FunctionCall fc
+where fc.getTarget().getQualifiedName() = "LogToSystemLogStructured"
+    and fc.getArgument(_) instanceof StringLiteral
+    and not fc.getArgument(_).toString() = "MESSAGE"
+select fc, "LogToSystemLogStructured requires the terminating key-value pair containing the \"MESSAGE\" key"


### PR DESCRIPTION
This CodeQL query looks for function calls to the `LogToSystemlogStructured` function where the terminating key-value pair is missing.